### PR TITLE
Add multi-types case in unnest_key macro

### DIFF
--- a/macros/unnest_key.sql
+++ b/macros/unnest_key.sql
@@ -8,6 +8,10 @@
     (select 
         {% if value_type == "lower_string_value" %}
             lower(value.string_value)   
+        {% elif value_type == "multiple_values_to_string" %}
+            COALESCE(CAST(value.int_value AS STRING), CAST(value.float_value AS STRING), CAST(value.double_value AS STRING), value.string_value) 
+        {% elif value_type == "multiple_number_values" %}
+            COALESCE(value.int_value , value.float_value, value.double_value) 
         {% else %}
             value.{{value_type}}    
         {% endif %}


### PR DESCRIPTION
## Description & motivation
<!---
Add fix to consider multiple key columns in event_params for when a key can have different value types (int, float, double or string). Cases identified: tax, ga_client_id,  search_term and search_query
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
