### PR TITLE
Add double quotes to use values as STRING

### DIFF
--- a/macros/map_stream_id.sql
+++ b/macros/map_stream_id.sql
@@ -1,7 +1,7 @@
 {% macro map_stream_id(stream_id, stream_properties) -%}
 CASE
 {% for sp in stream_properties %}
-    WHEN {{ stream_id }} = {{ sp.stream_id }} THEN {{ sp.stream_name }}
+    WHEN {{ stream_id }} = "{{ sp.stream_id }}" THEN "{{ sp.stream_name }}"
 {% endfor %}
 	ELSE "new_stream"
 END


### PR DESCRIPTION
## Description & motivation
<!---
Fix map_stream_id macro by adding double quotes to variables
-->

## Checklist
- [x] I have verified that these changes work locally
- [ ] I have updated the README.md (if applicable)
- [ ] I have added tests & descriptions to my models (and macros if applicable)
- [ ] I have run `dbt test` and `python -m pytest .` to validate existing tests
