### PR TITLE
Feature/BI-890

### DIFF
--- a/macros/create_custom_event.sql
+++ b/macros/create_custom_event.sql
@@ -13,6 +13,6 @@
     from {{ref('stg_ga4__events')}}
     where event_name = '{{event_name}}'
     {% if is_incremental() %}
-        and event_date_dt = CURRENT_DATE()
+        and event_date_dt >= CURRENT_DATE() - 7
     {% endif %}
 {%- endmacro -%}

--- a/macros/create_custom_event.sql
+++ b/macros/create_custom_event.sql
@@ -12,4 +12,7 @@
         {% endif %}
     from {{ref('stg_ga4__events')}}
     where event_name = '{{event_name}}'
+    {% if is_incremental() %}
+        and event_date_dt = CURRENT_DATE()
+    {% endif %}
 {%- endmacro -%}

--- a/models/staging/events/stg_ga4__event_click.sql
+++ b/models/staging/events/stg_ga4__event_click.sql
@@ -28,7 +28,7 @@
  from {{ref('stg_ga4__events')}}
  where event_name = 'click'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_click.sql
+++ b/models/staging/events/stg_ga4__event_click.sql
@@ -1,5 +1,11 @@
 -- reference here: https://support.google.com/analytics/answer/9216061?hl=en 
- 
+
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with click_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
@@ -21,6 +27,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}
  where event_name = 'click'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from click_with_params

--- a/models/staging/events/stg_ga4__event_file_download.sql
+++ b/models/staging/events/stg_ga4__event_file_download.sql
@@ -1,5 +1,11 @@
  -- reference here: https://support.google.com/analytics/answer/9216061?hl=en&ref_topic=9756175
- 
+
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with event_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
@@ -19,6 +25,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'file_download'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from event_with_params

--- a/models/staging/events/stg_ga4__event_file_download.sql
+++ b/models/staging/events/stg_ga4__event_file_download.sql
@@ -26,7 +26,7 @@
  from {{ref('stg_ga4__events')}}    
  where event_name = 'file_download'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_first_visit.sql
+++ b/models/staging/events/stg_ga4__event_first_visit.sql
@@ -1,5 +1,11 @@
 -- TODO: Unclear why there are first_visit events firing when the ga_session_number is >1. This might cause confusion.
 
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
 with first_visit_with_params as (
  select 
     *,
@@ -12,6 +18,9 @@ with first_visit_with_params as (
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'first_visit'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from first_visit_with_params

--- a/models/staging/events/stg_ga4__event_first_visit.sql
+++ b/models/staging/events/stg_ga4__event_first_visit.sql
@@ -19,7 +19,7 @@ with first_visit_with_params as (
  from {{ref('stg_ga4__events')}}    
  where event_name = 'first_visit'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_scroll.sql
+++ b/models/staging/events/stg_ga4__event_scroll.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with scroll_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'percent_scrolled', 'int_value') }}
@@ -9,6 +15,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'scroll'
+ {% if is_incremental() %}
+    and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from scroll_with_params

--- a/models/staging/events/stg_ga4__event_scroll.sql
+++ b/models/staging/events/stg_ga4__event_scroll.sql
@@ -16,7 +16,7 @@
  from {{ref('stg_ga4__events')}}    
  where event_name = 'scroll'
  {% if is_incremental() %}
-    and event_date_dt = CURRENT_DATE()
+    and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_session_start.sql
+++ b/models/staging/events/stg_ga4__event_session_start.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with session_start_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
@@ -10,6 +16,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'session_start'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from session_start_with_params

--- a/models/staging/events/stg_ga4__event_session_start.sql
+++ b/models/staging/events/stg_ga4__event_session_start.sql
@@ -17,7 +17,7 @@
  from {{ref('stg_ga4__events')}}    
  where event_name = 'session_start'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_user_engagement.sql
+++ b/models/staging/events/stg_ga4__event_user_engagement.sql
@@ -17,7 +17,7 @@
  from {{ref('stg_ga4__events')}}    
  where event_name = 'user_engagement'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_user_engagement.sql
+++ b/models/staging/events/stg_ga4__event_user_engagement.sql
@@ -1,5 +1,11 @@
 -- Event defined as "when the app is in the foreground or webpage is in focus for at least one second."
  
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with user_engagement_with_params as (
    select *
       {% if var("default_custom_parameters", "none") != "none" %}
@@ -10,6 +16,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'user_engagement'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from user_engagement_with_params

--- a/models/staging/events/stg_ga4__event_video_complete.sql
+++ b/models/staging/events/stg_ga4__event_video_complete.sql
@@ -1,6 +1,12 @@
 -- Defined as when the video ends. For embedded YouTube videos that have JS API support enabled. Collected by default via enhanced measurement.
 -- More info: https://support.google.com/firebase/answer/9234069?hl=en
- 
+
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with video_complete_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'video_current_time', 'int_value') }},
@@ -18,6 +24,9 @@
       {% endif %}
  from {{ ref('stg_ga4__events') }}    
  where event_name = 'video_complete'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from video_complete_with_params

--- a/models/staging/events/stg_ga4__event_video_complete.sql
+++ b/models/staging/events/stg_ga4__event_video_complete.sql
@@ -25,7 +25,7 @@
  from {{ ref('stg_ga4__events') }}    
  where event_name = 'video_complete'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_video_start.sql
+++ b/models/staging/events/stg_ga4__event_video_start.sql
@@ -1,6 +1,12 @@
 -- Defined as when the video starts playing. For embedded YouTube videos that have JS API support enabled. Collected by default via enhanced measurement.
 -- More info: https://support.google.com/firebase/answer/9234069?hl=en
  
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with video_start_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'video_current_time', 'int_value') }},
@@ -18,6 +24,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}    
  where event_name = 'video_start'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from video_start_with_params

--- a/models/staging/events/stg_ga4__event_video_start.sql
+++ b/models/staging/events/stg_ga4__event_video_start.sql
@@ -25,7 +25,7 @@
  from {{ref('stg_ga4__events')}}    
  where event_name = 'video_start'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/events/stg_ga4__event_view_search_results.sql
+++ b/models/staging/events/stg_ga4__event_view_search_results.sql
@@ -1,5 +1,11 @@
 -- reference here: https://support.google.com/analytics/answer/9216061?hl=en 
- 
+
+{{
+  config(
+    materialized='incremental'
+  )
+}}
+
  with event_with_params as (
    select *,
       {{ ga4.unnest_key('event_params', 'entrances',  'int_value') }},
@@ -13,6 +19,9 @@
       {% endif %}
  from {{ref('stg_ga4__events')}}
  where event_name = 'view_search_results'
+ {% if is_incremental() %}
+  and event_date_dt = CURRENT_DATE()
+ {% endif %}
 )
 
 select * from event_with_params

--- a/models/staging/events/stg_ga4__event_view_search_results.sql
+++ b/models/staging/events/stg_ga4__event_view_search_results.sql
@@ -20,7 +20,7 @@
  from {{ref('stg_ga4__events')}}
  where event_name = 'view_search_results'
  {% if is_incremental() %}
-  and event_date_dt = CURRENT_DATE()
+  and event_date_dt >= CURRENT_DATE() - 7
  {% endif %}
 )
 

--- a/models/staging/stg_ga4__event_items.sql
+++ b/models/staging/stg_ga4__event_items.sql
@@ -40,7 +40,7 @@ with items_with_params as (
         unnest(items) as i
     where event_name in ('add_payment_info', 'add_shipping_info', 'add_to_cart','add_to_wishlist','begin_checkout' ,'purchase','refund', 'remove_from_cart','select_item', 'select_promotion','view_item_list','view_promotion', 'view_item')
     {% if is_incremental() %}
-        and event_date_dt = CURRENT_DATE()
+        and event_date_dt >= CURRENT_DATE() - 7
     {% endif %}
 )
 

--- a/models/staging/stg_ga4__event_items.sql
+++ b/models/staging/stg_ga4__event_items.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
 with items_with_params as (
     select
         event_key,
@@ -33,6 +39,9 @@ with items_with_params as (
     from {{ref('stg_ga4__events')}},
         unnest(items) as i
     where event_name in ('add_payment_info', 'add_shipping_info', 'add_to_cart','add_to_wishlist','begin_checkout' ,'purchase','refund', 'remove_from_cart','select_item', 'select_promotion','view_item_list','view_promotion', 'view_item')
+    {% if is_incremental() %}
+        and event_date_dt = CURRENT_DATE()
+    {% endif %}
 )
 
 select * from items_with_params

--- a/models/staging/stg_ga4__event_to_query_string_params.sql
+++ b/models/staging/stg_ga4__event_to_query_string_params.sql
@@ -1,9 +1,18 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
 with event_and_query_string as 
 (
     select 
         event_key,
         split(page_query_string, '&') as qs_split
     from {{ref('stg_ga4__events')}}
+    {% if is_incremental() %}
+        event_date_dt = CURRENT_DATE()
+    {% endif %}
 ),
 flattened_qs as
 (

--- a/models/staging/stg_ga4__event_to_query_string_params.sql
+++ b/models/staging/stg_ga4__event_to_query_string_params.sql
@@ -11,7 +11,7 @@ with event_and_query_string as
         split(page_query_string, '&') as qs_split
     from {{ref('stg_ga4__events')}}
     {% if is_incremental() %}
-        event_date_dt = CURRENT_DATE()
+        where event_date_dt >= CURRENT_DATE() - 7
     {% endif %}
 ),
 flattened_qs as

--- a/models/staging/stg_ga4__page_conversions.sql
+++ b/models/staging/stg_ga4__page_conversions.sql
@@ -1,5 +1,6 @@
 {{ config(
-  enabled= var('conversion_events', false) != false
+  enabled= var('conversion_events', false) != false,
+  materialized='incremental'
 ) }}
 
 select 
@@ -8,4 +9,7 @@ select
     , countif(event_name = '{{ce}}') as {{ce}}_count
     {% endfor %}
 from {{ref('stg_ga4__events')}}
+{% if is_incremental() %}
+  where event_date_dt = CURRENT_DATE()
+{% endif %}
 group by 1

--- a/models/staging/stg_ga4__page_conversions.sql
+++ b/models/staging/stg_ga4__page_conversions.sql
@@ -10,6 +10,6 @@ select
     {% endfor %}
 from {{ref('stg_ga4__events')}}
 {% if is_incremental() %}
-  where event_date_dt = CURRENT_DATE()
+  where event_date_dt >= CURRENT_DATE() - 7
 {% endif %}
 group by 1

--- a/models/staging/stg_ga4__page_engaged_time.sql
+++ b/models/staging/stg_ga4__page_engaged_time.sql
@@ -1,8 +1,17 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
 with pek_time as (
 select
     page_engagement_key,
     sum(engagement_time_msec) as page_engagement_time,
 from {{ ref('stg_ga4__events') }}
+{% if is_incremental() %}
+    where event_date_dt = CURRENT_DATE()
+{% endif %}
 group by 1
 ),
 matched_pv as ( -- need to replace the pek with one that uses page_location to match back to correct page_view

--- a/models/staging/stg_ga4__page_engaged_time.sql
+++ b/models/staging/stg_ga4__page_engaged_time.sql
@@ -10,7 +10,7 @@ select
     sum(engagement_time_msec) as page_engagement_time,
 from {{ ref('stg_ga4__events') }}
 {% if is_incremental() %}
-    where event_date_dt = CURRENT_DATE()
+    where event_date_dt >= CURRENT_DATE() - 7
 {% endif %}
 group by 1
 ),

--- a/models/staging/stg_ga4__sessions_first_last_pageviews.sql
+++ b/models/staging/stg_ga4__sessions_first_last_pageviews.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
 with page_views_first_last as (
     select
         stream_name,
@@ -6,6 +12,9 @@ with page_views_first_last as (
         LAST_VALUE(event_key) OVER (PARTITION BY session_key ORDER BY event_timestamp ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS last_page_view_event_key
     from {{ref('stg_ga4__events')}}
     where event_name = 'page_view'
+    {% if is_incremental() %}
+        and event_date_dt = CURRENT_DATE()
+    {% endif %}
 ),
 page_views_by_session_key as (
     select distinct

--- a/models/staging/stg_ga4__sessions_first_last_pageviews.sql
+++ b/models/staging/stg_ga4__sessions_first_last_pageviews.sql
@@ -13,7 +13,7 @@ with page_views_first_last as (
     from {{ref('stg_ga4__events')}}
     where event_name = 'page_view'
     {% if is_incremental() %}
-        and event_date_dt = CURRENT_DATE()
+        and event_date_dt >= CURRENT_DATE() - 7
     {% endif %}
 ),
 page_views_by_session_key as (

--- a/models/staging/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources.sql
@@ -20,7 +20,7 @@ with session_events as (
     and event_name != 'session_start'
     and event_name != 'first_visit'
     {% if is_incremental() %}
-        and event_date_dt = CURRENT_DATE()
+        and event_date_dt >= CURRENT_DATE() - 7
     {% endif %}
    ),
 set_default_channel_grouping as (

--- a/models/staging/stg_ga4__sessions_traffic_sources.sql
+++ b/models/staging/stg_ga4__sessions_traffic_sources.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental'
+    )
+}}
+
 with session_events as (
     select 
         session_key
@@ -13,6 +19,9 @@ with session_events as (
     where session_key is not null
     and event_name != 'session_start'
     and event_name != 'first_visit'
+    {% if is_incremental() %}
+        and event_date_dt = CURRENT_DATE()
+    {% endif %}
    ),
 set_default_channel_grouping as (
     select


### PR DESCRIPTION
The following have been changed from **view** to **incremental**:

**Models**
- `stg_ga4__sessions_traffic_sources`
- `stg_ga4__event_to_query_string_params`
- `stg_ga4__sessions_first_last_pageviews`
- `stg_ga4__event_items`
- `stg_ga4__page_engaged_time`
- `stg_ga4__page_conversions`
- `stg_ga4__event_scroll`
- `stg_ga4__event_video_complete`
- `stg_ga4__event_session_start`
- `stg_ga4__event_video_start`
- `stg_ga4__event_click`
- `stg_ga4__event_first_visit`
- `stg_ga4__event_file_download`
- `stg_ga4__event_user_engagement`
- `stg_ga4__event_view_search_results`

**Macros**:
- `ga4.create_custom_event`
  - Referenced by `stg_ga4__event_mq_funnel`, `stg_ga4__event_mq_answers`, `stg_ga4__event_purchase` in `ETL-Pipeline` repo